### PR TITLE
Add support for PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpcs-cache
+/.phpunit.result.cache
 /clover.xml
 /coveralls-upload.json
 /phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /clover.xml
 /coveralls-upload.json
 /phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "league/plates": "^3.3",
@@ -39,7 +39,7 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~2.1.0",
+        "laminas/laminas-coding-standard": "~2.1.4",
         "malukenho/docheader": "^0.1.6",
         "phpunit/phpunit": "^9.3",
         "phpspec/prophecy-phpunit": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ^8.0",
         "laminas/laminas-escaper": "^2.5",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "league/plates": "^3.3",
@@ -39,9 +39,10 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "malukenho/docheader": "^0.1.5",
-        "phpunit/phpunit": "^7.0.2"
+        "laminas/laminas-coding-standard": "~2.1.0",
+        "malukenho/docheader": "^0.1.6",
+        "phpunit/phpunit": "^9.3",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "025ed61bcc0c71b2a90dfe6fc96375ad",
+    "content-hash": "016347994b0ca7807d6366c44fd023e9",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -692,6 +692,76 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -762,31 +832,37 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38",
                 "shasum": ""
             },
             "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -800,7 +876,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-10-26T07:33:05+00:00"
         },
         {
             "name": "malukenho/docheader",
@@ -917,29 +999,86 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "name": "nikic/php-parser",
+            "version": "v4.10.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+            },
+            "time": "2020-12-20T10:01:03+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -973,24 +1112,24 @@
                 "issues": "https://github.com/phar-io/manifest/issues",
                 "source": "https://github.com/phar-io/manifest/tree/master"
             },
-            "time": "2018-07-08T19:23:20+00:00"
+            "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1022,9 +1161,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/master"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2018-07-08T19:19:57+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1252,41 +1391,150 @@
             "time": "2020-12-19T10:15:11+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:33:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -1314,34 +1562,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/master"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
             },
-            "time": "2018-10-31T16:06:48+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:44:49+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1368,7 +1622,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
             },
             "funding": [
                 {
@@ -1376,26 +1630,97 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2020-09-28T05:57:25+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1419,34 +1744,40 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
-            "time": "2015-06-21T13:50:34+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.3",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1472,7 +1803,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1480,117 +1811,59 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:20:02+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "9.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3",
+                "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -1598,12 +1871,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1626,34 +1902,156 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/7.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
             },
-            "time": "2020-01-08T08:45:45+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-02-02T14:45:58+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.2",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1675,7 +2073,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -1683,34 +2081,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:15:22+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1749,7 +2147,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1757,33 +2155,90 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:04:30+00:00"
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.3",
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1815,7 +2270,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
             },
             "funding": [
                 {
@@ -1823,27 +2278,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.4",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1851,7 +2306,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1878,7 +2333,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
             },
             "funding": [
                 {
@@ -1886,34 +2341,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:53:42+00:00"
+            "time": "2020-09-28T05:52:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1955,7 +2410,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
             },
             "funding": [
                 {
@@ -1963,27 +2418,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2020-09-28T05:24:23+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1991,7 +2449,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2016,36 +2474,99 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
             },
-            "time": "2017-04-27T15:39:26+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:55:19+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.4",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2067,7 +2588,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2075,32 +2596,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:40:27+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2122,7 +2643,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -2130,32 +2651,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:37:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2185,7 +2706,7 @@
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
             },
             "funding": [
                 {
@@ -2193,29 +2714,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:34:24+00:00"
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2237,7 +2761,7 @@
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
             },
             "funding": [
                 {
@@ -2245,29 +2769,85 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:30:19+00:00"
+            "time": "2020-09-28T06:45:17+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "2.0.1",
+            "name": "sebastian/type",
+            "version": "2.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:18:59+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2290,69 +2870,109 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/master"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
-            "time": "2016-10-03T07:35:21+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2365,7 +2985,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -2375,7 +2995,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/console",
@@ -3234,6 +3854,61 @@
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "fbeb31ee876b3c493779d3aa717ebb57ef258e6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/fbeb31ee876b3c493779d3aa717ebb57ef258e6a",
+                "reference": "fbeb31ee876b3c493779d3aa717ebb57ef258e6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.5.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.4.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-11T18:13:55+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.9.1",
             "source": {
@@ -3293,7 +3968,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.3 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "016347994b0ca7807d6366c44fd023e9",
+    "content-hash": "0f7f4c8a4456bc85bec1acf7b4487364",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -3968,7 +3968,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ^8.0"
+        "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,10 +1,24 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
-    <!-- Paths to check -->
-    <file>src</file>
-    <file>test</file>
-    <exclude-pattern>*/test/TestAsset/plates-null.php</exclude-pattern>
-    <exclude-pattern>*/test/TestAsset/test/test.php</exclude-pattern>
+  <arg name="basepath" value="."/>
+  <arg name="cache" value=".phpcs-cache"/>
+  <arg name="colors"/>
+  <arg name="extensions" value="php"/>
+  <arg name="parallel" value="80"/>
+
+  <!-- Show progress -->
+  <arg value="p"/>
+
+  <!-- Paths to check -->
+  <file>src</file>
+  <file>test</file>
+  <exclude-pattern>*/test/TestAsset/plates.php</exclude-pattern>
+  <exclude-pattern>*/test/TestAsset/plates-2.php</exclude-pattern>
+  <exclude-pattern>*/test/TestAsset/plates-null.php</exclude-pattern>
+  <exclude-pattern>*/test/TestAsset/test/test.php</exclude-pattern>
+
+  <!-- Include all rules from the Laminas Coding Standard -->
+  <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,18 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<?xml version="1.0"?>
+<phpunit 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    bootstrap="./vendor/autoload.php"
+    colors="true"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+
     <testsuites>
         <testsuite name="Mezzio Plates Tests">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -14,23 +14,23 @@ use Mezzio\Template\TemplateRendererInterface;
 
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
-            'templates' => $this->getTemplates(),
+            'templates'    => $this->getTemplates(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
-            'aliases' => [
+            'aliases'   => [
                 TemplateRendererInterface::class => PlatesRenderer::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Template\TemplateRendererInterface::class => TemplateRendererInterface::class,
-                \Zend\Expressive\Plates\PlatesRenderer::class => PlatesRenderer::class,
+                \Zend\Expressive\Plates\PlatesRenderer::class              => PlatesRenderer::class,
             ],
             'factories' => [
                 PlatesRenderer::class => PlatesRendererFactory::class,
@@ -38,11 +38,11 @@ class ConfigProvider
         ];
     }
 
-    public function getTemplates() : array
+    public function getTemplates(): array
     {
         return [
             'extension' => 'phtml',
-            'paths' => [],
+            'paths'     => [],
         ];
     }
 }

--- a/src/Extension/EscaperExtension.php
+++ b/src/Extension/EscaperExtension.php
@@ -16,15 +16,10 @@ use League\Plates\Extension\ExtensionInterface;
 
 class EscaperExtension implements ExtensionInterface
 {
-    /**
-     * @var Escaper
-     */
+    /** @var Escaper */
     private $escaper;
 
-    /**
-     * EscaperExtension constructor.
-     */
-    public function __construct(string $encoding = null)
+    public function __construct(?string $encoding = null)
     {
         $this->escaper = new Escaper($encoding);
     }
@@ -39,11 +34,8 @@ class EscaperExtension implements ExtensionInterface
      * - escapeJs($string) : string
      * - escapeCss($string) : string
      * - escapeUrl($string) : string
-     *
-     * @param Engine $engine
-     * @return void
      */
-    public function register(Engine $engine) : void
+    public function register(Engine $engine): void
     {
         $engine->registerFunction('escapeHtml', [$this->escaper, 'escapeHtml']);
         $engine->registerFunction('escapeHtmlAttr', [$this->escaper, 'escapeHtmlAttr']);

--- a/src/Extension/EscaperExtensionFactory.php
+++ b/src/Extension/EscaperExtensionFactory.php
@@ -30,7 +30,7 @@ class EscaperExtensionFactory
     /**
      * @throws InvalidArgumentException
      */
-    public function __invoke(ContainerInterface $container) : EscaperExtension
+    public function __invoke(ContainerInterface $container): EscaperExtension
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = $config['plates'] ?? [];

--- a/src/Extension/UrlExtension.php
+++ b/src/Extension/UrlExtension.php
@@ -18,23 +18,15 @@ use Mezzio\Router\RouteResult;
 
 class UrlExtension implements ExtensionInterface
 {
-    /**
-     * @var ServerUrlHelper
-     */
+    /** @var ServerUrlHelper */
     private $serverUrlHelper;
 
-    /**
-     * @var UrlHelper
-     */
+    /** @var UrlHelper */
     private $urlHelper;
 
-    /**
-     * @param UrlHelper $urlHelper
-     * @param ServerUrlHelper $serverUrlHelper
-     */
     public function __construct(UrlHelper $urlHelper, ServerUrlHelper $serverUrlHelper)
     {
-        $this->urlHelper = $urlHelper;
+        $this->urlHelper       = $urlHelper;
         $this->serverUrlHelper = $serverUrlHelper;
     }
 
@@ -46,7 +38,7 @@ class UrlExtension implements ExtensionInterface
      * - url($route = null, array $params = []) : string
      * - serverurl($path = null) : string
      */
-    public function register(Engine $engine) : void
+    public function register(Engine $engine): void
     {
         $engine->registerFunction('url', $this->urlHelper);
         $engine->registerFunction('serverurl', $this->serverUrlHelper);
@@ -60,7 +52,7 @@ class UrlExtension implements ExtensionInterface
      *     used internally to back the route() Plates function; we now register
      *     the UrlHelper::getRouteResult callback directly.
      */
-    public function getRouteResult() : ?RouteResult
+    public function getRouteResult(): ?RouteResult
     {
         return $this->urlHelper->getRouteResult();
     }
@@ -68,17 +60,18 @@ class UrlExtension implements ExtensionInterface
     /**
      * Generate a URL from either the currently matched route or the specfied route.
      *
+     * @deprecated since 2.2.0; to be removed in 3.0.0. This method was originally
+     *     used internally to back the url() Plates function; we now register
+     *     UrlHelper instance directly, as it is callable.
+     *
      * @param array  $options Can have the following keys:
      *     - router (array): contains options to be passed to the router
      *     - reuse_result_params (bool): indicates if the current RouteResult
      *       parameters will be used, defaults to true
      * @return string
-     * @deprecated since 2.2.0; to be removed in 3.0.0. This method was originally
-     *     used internally to back the url() Plates function; we now register
-     *     UrlHelper instance directly, as it is callable.
      */
     public function generateUrl(
-        string $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
         ?string $fragmentIdentifier = null,
@@ -94,7 +87,7 @@ class UrlExtension implements ExtensionInterface
      *     used internally to back the serverurl() Plates function; we now register
      *     the ServerUrl instance directly, as it is callable.
      */
-    public function generateServerUrl(string $path = null) : string
+    public function generateServerUrl(?string $path = null): string
     {
         return $this->serverUrlHelper->generate($path);
     }

--- a/src/Extension/UrlExtensionFactory.php
+++ b/src/Extension/UrlExtensionFactory.php
@@ -23,13 +23,14 @@ use function sprintf;
 class UrlExtensionFactory
 {
     /**
-     * @throws MissingHelperException if UrlHelper service is missing.
-     * @throws MissingHelperException if ServerUrlHelper service is missing.
+     * @throws MissingHelperException If UrlHelper service is missing.
+     * @throws MissingHelperException If ServerUrlHelper service is missing.
      */
-    public function __invoke(ContainerInterface $container) : UrlExtension
+    public function __invoke(ContainerInterface $container): UrlExtension
     {
-        if (! $container->has(UrlHelper::class)
-            && ! $container->has(\Zend\Expressive\Helper\UrlHelper::class)
+        if (
+            ! $container->has(UrlHelper::class)
+            && ! $container->has(\Mezzio\Helper\UrlHelper::class)
         ) {
             throw new MissingHelperException(sprintf(
                 '%s requires that the %s service be present; not found',
@@ -38,8 +39,9 @@ class UrlExtensionFactory
             ));
         }
 
-        if (! $container->has(ServerUrlHelper::class)
-            && ! $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)
+        if (
+            ! $container->has(ServerUrlHelper::class)
+            && ! $container->has(\Mezzio\Helper\ServerUrlHelper::class)
         ) {
             throw new MissingHelperException(sprintf(
                 '%s requires that the %s service be present; not found',
@@ -51,10 +53,10 @@ class UrlExtensionFactory
         return new UrlExtension(
             $container->has(UrlHelper::class)
                 ? $container->get(UrlHelper::class)
-                : $container->get(\Zend\Expressive\Helper\UrlHelper::class),
+                : $container->get(\Mezzio\Helper\UrlHelper::class),
             $container->has(ServerUrlHelper::class)
                 ? $container->get(ServerUrlHelper::class)
-                : $container->get(\Zend\Expressive\Helper\ServerUrlHelper::class)
+                : $container->get(\Mezzio\Helper\ServerUrlHelper::class)
         );
     }
 }

--- a/src/Extension/UrlExtensionFactory.php
+++ b/src/Extension/UrlExtensionFactory.php
@@ -30,7 +30,7 @@ class UrlExtensionFactory
     {
         if (
             ! $container->has(UrlHelper::class)
-            && ! $container->has(\Mezzio\Helper\UrlHelper::class)
+            && ! $container->has(UrlHelper::class)
         ) {
             throw new MissingHelperException(sprintf(
                 '%s requires that the %s service be present; not found',
@@ -41,7 +41,7 @@ class UrlExtensionFactory
 
         if (
             ! $container->has(ServerUrlHelper::class)
-            && ! $container->has(\Mezzio\Helper\ServerUrlHelper::class)
+            && ! $container->has(ServerUrlHelper::class)
         ) {
             throw new MissingHelperException(sprintf(
                 '%s requires that the %s service be present; not found',
@@ -53,10 +53,10 @@ class UrlExtensionFactory
         return new UrlExtension(
             $container->has(UrlHelper::class)
                 ? $container->get(UrlHelper::class)
-                : $container->get(\Mezzio\Helper\UrlHelper::class),
+                : $container->get(UrlHelper::class),
             $container->has(ServerUrlHelper::class)
                 ? $container->get(ServerUrlHelper::class)
-                : $container->get(\Mezzio\Helper\ServerUrlHelper::class)
+                : $container->get(ServerUrlHelper::class)
         );
     }
 }

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -47,7 +47,7 @@ use function sprintf;
  */
 class PlatesEngineFactory
 {
-    public function __invoke(ContainerInterface $container) : PlatesEngine
+    public function __invoke(ContainerInterface $container): PlatesEngine
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = $config['plates'] ?? [];
@@ -74,7 +74,7 @@ class PlatesEngineFactory
      * Otherwise, instantiates the UrlExtensionFactory, and invokes it with
      * the container, loading the result into the engine.
      */
-    private function injectUrlExtension(ContainerInterface $container, PlatesEngine $engine) : void
+    private function injectUrlExtension(ContainerInterface $container, PlatesEngine $engine): void
     {
         if ($container->has(Extension\UrlExtension::class)) {
             $engine->loadExtension($container->get(Extension\UrlExtension::class));
@@ -99,7 +99,7 @@ class PlatesEngineFactory
      * Otherwise, instantiates the EscaperExtensionFactory, and invokes it with
      * the container, loading the result into the engine.
      */
-    private function injectEscaperExtension(ContainerInterface $container, PlatesEngine $engine) : void
+    private function injectEscaperExtension(ContainerInterface $container, PlatesEngine $engine): void
     {
         if ($container->has(Extension\EscaperExtension::class)) {
             $engine->loadExtension($container->get(Extension\EscaperExtension::class));
@@ -113,7 +113,7 @@ class PlatesEngineFactory
     /**
      * Inject all configured extensions into the engine.
      */
-    private function injectExtensions(ContainerInterface $container, PlatesEngine $engine, array $extensions) : void
+    private function injectExtensions(ContainerInterface $container, PlatesEngine $engine, array $extensions): void
     {
         foreach ($extensions as $extension) {
             $this->injectExtension($container, $engine, $extension);
@@ -132,12 +132,12 @@ class PlatesEngineFactory
      * If anything else is provided, an exception is raised.
      *
      * @param ExtensionInterface|string $extension
-     * @throws Exception\InvalidExtensionException for non-string,
+     * @throws Exception\InvalidExtensionException For non-string,
      *     non-extension $extension values.
-     * @throws Exception\InvalidExtensionException for string $extension values
+     * @throws Exception\InvalidExtensionException For string $extension values
      *     that do not resolve to an extension instance.
      */
-    private function injectExtension(ContainerInterface $container, PlatesEngine $engine, $extension) : void
+    private function injectExtension(ContainerInterface $container, PlatesEngine $engine, $extension): void
     {
         if ($extension instanceof ExtensionInterface) {
             $engine->loadExtension($extension);
@@ -147,15 +147,15 @@ class PlatesEngineFactory
         if (! is_string($extension)) {
             throw new Exception\InvalidExtensionException(sprintf(
                 '%s expects extension instances, service names, or class names; received %s',
-                __CLASS__,
-                (is_object($extension) ? get_class($extension) : gettype($extension))
+                self::class,
+                is_object($extension) ? get_class($extension) : gettype($extension)
             ));
         }
 
         if (! $container->has($extension) && ! class_exists($extension)) {
             throw new Exception\InvalidExtensionException(sprintf(
                 '%s expects extension service names or class names; "%s" does not resolve to either',
-                __CLASS__,
+                self::class,
                 $extension
             ));
         }
@@ -167,9 +167,9 @@ class PlatesEngineFactory
         if (! $extension instanceof ExtensionInterface) {
             throw new Exception\InvalidExtensionException(sprintf(
                 '%s expects extension services to implement %s ; received %s',
-                __CLASS__,
+                self::class,
                 ExtensionInterface::class,
-                (is_object($extension) ? get_class($extension) : gettype($extension))
+                is_object($extension) ? get_class($extension) : gettype($extension)
             ));
         }
 

--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Mezzio\Plates;
 
 use League\Plates\Engine;
+use League\Plates\Template\Folder;
 use Mezzio\Template\ArrayParametersTrait;
 use Mezzio\Template\Exception;
 use Mezzio\Template\TemplatePath;
@@ -33,12 +34,10 @@ class PlatesRenderer implements TemplateRendererInterface
 {
     use ArrayParametersTrait;
 
-    /**
-     * @var Engine
-     */
+    /** @var Engine */
     private $template;
 
-    public function __construct(Engine $template = null)
+    public function __construct(?Engine $template = null)
     {
         if (null === $template) {
             $template = $this->createTemplate();
@@ -49,7 +48,7 @@ class PlatesRenderer implements TemplateRendererInterface
     /**
      * {@inheritDoc}
      */
-    public function render(string $name, $params = []) : string
+    public function render(string $name, $params = []): string
     {
         $params = $this->normalizeParams($params);
         return $this->template->render($name, $params);
@@ -63,7 +62,7 @@ class PlatesRenderer implements TemplateRendererInterface
      * folders, only the default directory; overwriting the default directory
      * is likely unintended.
      */
-    public function addPath(string $path, string $namespace = null) : void
+    public function addPath(string $path, ?string $namespace = null): void
     {
         if (! $namespace && ! $this->template->getDirectory()) {
             $this->template->setDirectory($path);
@@ -81,10 +80,10 @@ class PlatesRenderer implements TemplateRendererInterface
     /**
      * {@inheritDoc}
      */
-    public function getPaths() : array
+    public function getPaths(): array
     {
         $paths = $this->template->getDirectory()
-            ? [ $this->getDefaultPath() ]
+            ? [$this->getDefaultPath()]
             : [];
 
         foreach ($this->getPlatesFolders() as $folder) {
@@ -98,7 +97,7 @@ class PlatesRenderer implements TemplateRendererInterface
      *
      * {@inheritDoc}
      */
-    public function addDefaultParam(string $templateName, string $param, $value) : void
+    public function addDefaultParam(string $templateName, string $param, $value): void
     {
         if (! is_string($templateName) || empty($templateName)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -123,11 +122,10 @@ class PlatesRenderer implements TemplateRendererInterface
         $this->template->addData($params, $templateName);
     }
 
-
     /**
      * Create a default Plates engine
      */
-    private function createTemplate() : Engine
+    private function createTemplate(): Engine
     {
         return new Engine();
     }
@@ -135,7 +133,7 @@ class PlatesRenderer implements TemplateRendererInterface
     /**
      * Create and return a TemplatePath representing the default Plates directory.
      */
-    private function getDefaultPath() : TemplatePath
+    private function getDefaultPath(): TemplatePath
     {
         return new TemplatePath($this->template->getDirectory());
     }
@@ -143,12 +141,12 @@ class PlatesRenderer implements TemplateRendererInterface
     /**
      * Return the internal array of plates folders.
      *
-     * @return \League\Plates\Template\Folder[]
+     * @return Folder[]
      */
-    private function getPlatesFolders() : array
+    private function getPlatesFolders(): array
     {
         $folders = $this->template->getFolders();
-        $r = new ReflectionProperty($folders, 'folders');
+        $r       = new ReflectionProperty($folders, 'folders');
         $r->setAccessible(true);
         return $r->getValue($folders);
     }

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -40,7 +40,7 @@ use function is_numeric;
  */
 class PlatesRendererFactory
 {
-    public function __invoke(ContainerInterface $container) : PlatesRenderer
+    public function __invoke(ContainerInterface $container): PlatesRenderer
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $config = $config['templates'] ?? [];
@@ -76,7 +76,7 @@ class PlatesRendererFactory
      * Otherwise, invokes the PlatesEngineFactory with the $container to create
      * and return the instance.
      */
-    private function createEngine(ContainerInterface $container) : PlatesEngine
+    private function createEngine(ContainerInterface $container): PlatesEngine
     {
         if ($container->has(PlatesEngine::class)) {
             return $container->get(PlatesEngine::class);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,31 +15,30 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /**
-     * @var ConfigProvider
-     */
+    /** @var ConfigProvider */
     private $provider;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray() : array
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
 
         return $config;
     }
 
     /**
      * @depends testInvocationReturnsArray
+     * @param array $config
      */
-    public function testReturnedArrayContainsDependencies(array $config) : void
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertArrayHasKey('templates', $config);
-        $this->assertInternalType('array', $config['dependencies']);
+        $this->assertIsArray($config['dependencies']);
     }
 }

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -23,12 +23,12 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function testExceptionInterfaceExtendsTemplateExceptionInterface() : void
+    public function testExceptionInterfaceExtendsTemplateExceptionInterface(): void
     {
         self::assertTrue(is_a(ExceptionInterface::class, TemplateExceptionInterface::class, true));
     }
 
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -43,9 +43,9 @@ class ExceptionTest extends TestCase
     /**
      * @dataProvider exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
-        self::assertContains('Exception', $exception);
+        self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/Extension/EscaperExtensionFactoryTest.php
+++ b/test/Extension/EscaperExtensionFactoryTest.php
@@ -15,15 +15,19 @@ use Laminas\Escaper\Exception\InvalidArgumentException;
 use Mezzio\Plates\Extension\EscaperExtension;
 use Mezzio\Plates\Extension\EscaperExtensionFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Container\ContainerInterface;
+use ReflectionClass;
 
 class EscaperExtensionFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ProphecyInterface */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
     }
@@ -32,7 +36,7 @@ class EscaperExtensionFactoryTest extends TestCase
     {
         $this->container->has('config')->willReturn(false);
 
-        $factory = new EscaperExtensionFactory();
+        $factory   = new EscaperExtensionFactory();
         $extension = $factory($this->container->reveal());
 
         $this->assertInstanceOf(EscaperExtension::class, $extension);
@@ -43,7 +47,7 @@ class EscaperExtensionFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([]);
 
-        $factory = new EscaperExtensionFactory();
+        $factory   = new EscaperExtensionFactory();
         $extension = $factory($this->container->reveal());
 
         $this->assertInstanceOf(EscaperExtension::class, $extension);
@@ -54,8 +58,8 @@ class EscaperExtensionFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'plates' => [
-                'encoding' => ''
-            ]
+                'encoding' => '',
+            ],
         ]);
 
         $factory = new EscaperExtensionFactory();
@@ -72,20 +76,20 @@ class EscaperExtensionFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn([
             'plates' => [
-                'encoding' => 'iso-8859-1'
-            ]
+                'encoding' => 'iso-8859-1',
+            ],
         ]);
 
-        $factory = new EscaperExtensionFactory();
+        $factory   = new EscaperExtensionFactory();
         $extension = $factory($this->container->reveal());
 
         $this->assertInstanceOf(EscaperExtension::class, $extension);
-        $this->assertAttributeInstanceOf(Escaper::class, 'escaper', $extension);
 
-        $class = new \ReflectionClass($extension);
+        $class   = new ReflectionClass($extension);
         $escaper = $class->getProperty('escaper');
         $escaper->setAccessible(true);
         $escaper = $escaper->getValue($extension);
+        $this->assertInstanceOf(Escaper::class, $escaper);
 
         $this->assertEquals('iso-8859-1', $escaper->getEncoding());
     }

--- a/test/Extension/EscaperExtensionTest.php
+++ b/test/Extension/EscaperExtensionTest.php
@@ -16,10 +16,13 @@ use Mezzio\Plates\Extension\EscaperExtension;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
+use Prophecy\PhpUnit\ProphecyTrait;
 use function is_array;
 
 class EscaperExtensionTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testRegistersEscaperFunctionsWithEngine()
     {
         $extension = new EscaperExtension();

--- a/test/Extension/EscaperExtensionTest.php
+++ b/test/Extension/EscaperExtensionTest.php
@@ -15,8 +15,8 @@ use League\Plates\Engine;
 use Mezzio\Plates\Extension\EscaperExtension;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-
 use Prophecy\PhpUnit\ProphecyTrait;
+
 use function is_array;
 
 class EscaperExtensionTest extends TestCase

--- a/test/Extension/UrlExtensionFactoryTest.php
+++ b/test/Extension/UrlExtensionFactoryTest.php
@@ -10,17 +10,21 @@ declare(strict_types=1);
 
 namespace MezzioTest\Plates\Extension;
 
+use League\Plates\Engine;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Plates\Exception\MissingHelperException;
 use Mezzio\Plates\Extension\UrlExtension;
 use Mezzio\Plates\Extension\UrlExtensionFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Container\ContainerInterface;
 
 class UrlExtensionFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ProphecyInterface */
     private $container;
 
@@ -30,38 +34,47 @@ class UrlExtensionFactoryTest extends TestCase
     /** @var ServerUrlHelper|ProphecyInterface */
     private $serverUrlHelper;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->container = $this->prophesize(ContainerInterface::class);
-        $this->urlHelper = $this->prophesize(UrlHelper::class);
+        $this->container       = $this->prophesize(ContainerInterface::class);
+        $this->urlHelper       = $this->prophesize(UrlHelper::class);
         $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
     }
 
     public function testFactoryReturnsUrlExtensionInstanceWhenHelpersArePresent()
     {
-        $this->container->has(UrlHelper::class)->willReturn(true);
-        $this->container->get(UrlHelper::class)->willReturn($this->urlHelper->reveal());
-        $this->container->has(ServerUrlHelper::class)->willReturn(true);
-        $this->container->get(ServerUrlHelper::class)->willReturn($this->serverUrlHelper->reveal());
+        $urlHelper = $this->urlHelper->reveal();
+        $serverUrlHelper = $this->serverUrlHelper->reveal();
 
-        $factory = new UrlExtensionFactory();
+        $this->container->has(UrlHelper::class)->willReturn(true);
+        $this->container->get(UrlHelper::class)->willReturn($urlHelper);
+        $this->container->has(ServerUrlHelper::class)->willReturn(true);
+        $this->container->get(ServerUrlHelper::class)->willReturn($serverUrlHelper);
+
+        $factory   = new UrlExtensionFactory();
         $extension = $factory($this->container->reveal());
         $this->assertInstanceOf(UrlExtension::class, $extension);
 
-        $this->assertAttributeSame($this->urlHelper->reveal(), 'urlHelper', $extension);
-        $this->assertAttributeSame($this->serverUrlHelper->reveal(), 'serverUrlHelper', $extension);
+        $engine = $this->createMock(Engine::class);
+        $engine->method('registerFunction')
+            ->withConsecutive(
+                ['url', $this->equalTo($urlHelper)],
+                ['serverurl', $this->equalTo($serverUrlHelper)]
+            );
+
+        $extension->register($engine);
     }
 
     public function testFactoryRaisesExceptionIfUrlHelperIsMissing()
     {
         $this->container->has(UrlHelper::class)->willReturn(false);
-        $this->container->has(\Zend\Expressive\Helper\UrlHelper::class)->willReturn(false);
+        $this->container->has(\Mezzio\Helper\UrlHelper::class)->willReturn(false);
         $this->container->get(UrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Zend\Expressive\Helper\UrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(\Mezzio\Helper\UrlHelper::class)->shouldNotBeCalled();
         $this->container->has(ServerUrlHelper::class)->shouldNotBeCalled();
-        $this->container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->has(\Mezzio\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
         $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Zend\Expressive\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(\Mezzio\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
 
         $factory = new UrlExtensionFactory();
 
@@ -74,11 +87,11 @@ class UrlExtensionFactoryTest extends TestCase
     {
         $this->container->has(UrlHelper::class)->willReturn(true);
         $this->container->get(UrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Zend\Expressive\Helper\UrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(\Mezzio\Helper\UrlHelper::class)->shouldNotBeCalled();
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(\Mezzio\Helper\ServerUrlHelper::class)->willReturn(false);
         $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Zend\Expressive\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(\Mezzio\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
 
         $factory = new UrlExtensionFactory();
 

--- a/test/Extension/UrlExtensionFactoryTest.php
+++ b/test/Extension/UrlExtensionFactoryTest.php
@@ -43,7 +43,7 @@ class UrlExtensionFactoryTest extends TestCase
 
     public function testFactoryReturnsUrlExtensionInstanceWhenHelpersArePresent()
     {
-        $urlHelper = $this->urlHelper->reveal();
+        $urlHelper       = $this->urlHelper->reveal();
         $serverUrlHelper = $this->serverUrlHelper->reveal();
 
         $this->container->has(UrlHelper::class)->willReturn(true);
@@ -68,13 +68,13 @@ class UrlExtensionFactoryTest extends TestCase
     public function testFactoryRaisesExceptionIfUrlHelperIsMissing()
     {
         $this->container->has(UrlHelper::class)->willReturn(false);
-        $this->container->has(\Mezzio\Helper\UrlHelper::class)->willReturn(false);
+        $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->get(UrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Mezzio\Helper\UrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(UrlHelper::class)->shouldNotBeCalled();
         $this->container->has(ServerUrlHelper::class)->shouldNotBeCalled();
-        $this->container->has(\Mezzio\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->has(ServerUrlHelper::class)->shouldNotBeCalled();
         $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Mezzio\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
 
         $factory = new UrlExtensionFactory();
 
@@ -87,11 +87,11 @@ class UrlExtensionFactoryTest extends TestCase
     {
         $this->container->has(UrlHelper::class)->willReturn(true);
         $this->container->get(UrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Mezzio\Helper\UrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(UrlHelper::class)->shouldNotBeCalled();
         $this->container->has(ServerUrlHelper::class)->willReturn(false);
-        $this->container->has(\Mezzio\Helper\ServerUrlHelper::class)->willReturn(false);
+        $this->container->has(ServerUrlHelper::class)->willReturn(false);
         $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
-        $this->container->get(\Mezzio\Helper\ServerUrlHelper::class)->shouldNotBeCalled();
+        $this->container->get(ServerUrlHelper::class)->shouldNotBeCalled();
 
         $factory = new UrlExtensionFactory();
 

--- a/test/Extension/UrlExtensionTest.php
+++ b/test/Extension/UrlExtensionTest.php
@@ -16,10 +16,13 @@ use Mezzio\Helper\UrlHelper;
 use Mezzio\Plates\Extension\UrlExtension;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 
 class UrlExtensionTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var UrlHelper|ProphecyInterface */
     private $urlHelper;
 
@@ -29,7 +32,7 @@ class UrlExtensionTest extends TestCase
     /** @var UrlExtension */
     private $extension;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->urlHelper       = $this->prophesize(UrlHelper::class);
         $this->serverUrlHelper = $this->prophesize(ServerUrlHelper::class);
@@ -56,7 +59,7 @@ class UrlExtensionTest extends TestCase
         $this->extension->register($engine->reveal());
     }
 
-    public function urlHelperParams()
+    public function urlHelperParams(): array
     {
         return [
             'null'             => [null, []],
@@ -68,11 +71,10 @@ class UrlExtensionTest extends TestCase
 
     /**
      * @dataProvider urlHelperParams
-     *
      * @param null|string $route
      * @param array $params
      */
-    public function testGenerateUrlProxiesToUrlHelper($route, array $params)
+    public function testGenerateUrlProxiesToUrlHelper($route, array $params): void
     {
         $this->urlHelper->generate($route, $params, [], null, [])->willReturn('/success');
         $this->assertEquals('/success', $this->extension->generateUrl($route, $params));
@@ -100,7 +102,7 @@ class UrlExtensionTest extends TestCase
         );
     }
 
-    public function serverUrlHelperParams()
+    public function serverUrlHelperParams(): array
     {
         return [
             'null'          => [null],
@@ -111,16 +113,15 @@ class UrlExtensionTest extends TestCase
 
     /**
      * @dataProvider serverUrlHelperParams
-     *
      * @param null|string $path
      */
-    public function testGenerateServerUrlProxiesToServerUrlHelper($path)
+    public function testGenerateServerUrlProxiesToServerUrlHelper($path): void
     {
         $this->serverUrlHelper->generate($path)->willReturn('/success');
         $this->assertEquals('/success', $this->extension->generateServerUrl($path));
     }
 
-    public function testGetRouteResultReturnsRouteResultWhenPopulated()
+    public function testGetRouteResultReturnsRouteResultWhenPopulated(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $this->urlHelper->getRouteResult()->willReturn($result->reveal());
@@ -128,7 +129,7 @@ class UrlExtensionTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $this->extension->getRouteResult());
     }
 
-    public function testGetRouteResultReturnsNullWhenRouteResultNotPopulatedInUrlHelper()
+    public function testGetRouteResultReturnsNullWhenRouteResultNotPopulatedInUrlHelper(): void
     {
         $this->urlHelper->getRouteResult()->willReturn(null);
 

--- a/test/PlatesRendererFactoryTest.php
+++ b/test/PlatesRendererFactoryTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace MezzioTest\Plates;
 
-use Laminas\Escaper\Escaper;
 use League\Plates\Engine;
 use League\Plates\Engine as PlatesEngine;
 use LogicException;
@@ -25,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Container\ContainerInterface;
+use ReflectionClass;
 use ReflectionProperty;
 
 use function restore_error_handler;
@@ -253,7 +253,7 @@ class PlatesRendererFactoryTest extends TestCase
         $factory  = new PlatesRendererFactory();
         $renderer = $factory($this->container->reveal());
 
-        $class   = new \ReflectionClass($renderer);
+        $class    = new ReflectionClass($renderer);
         $property = $class->getProperty('template');
         $property->setAccessible(true);
         $template = $property->getValue($renderer);

--- a/test/PlatesRendererFactoryTest.php
+++ b/test/PlatesRendererFactoryTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace MezzioTest\Plates;
 
+use Laminas\Escaper\Escaper;
+use League\Plates\Engine;
 use League\Plates\Engine as PlatesEngine;
 use LogicException;
 use Mezzio\Helper\ServerUrlHelper;
@@ -20,6 +22,7 @@ use Mezzio\Plates\PlatesRenderer;
 use Mezzio\Plates\PlatesRendererFactory;
 use Mezzio\Template\TemplatePath;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ProphecyInterface;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
@@ -32,20 +35,18 @@ use const E_USER_WARNING;
 
 class PlatesRendererFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|ProphecyInterface
-     */
+    use ProphecyTrait;
+
+    /** @var ContainerInterface|ProphecyInterface */
     private $container;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $errorCaught = false;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->errorCaught = false;
-        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->container   = $this->prophesize(ContainerInterface::class);
     }
 
     public function configureEngineService()
@@ -61,30 +62,30 @@ class PlatesRendererFactoryTest extends TestCase
         $this->container->get(ServerUrlHelper::class)->willReturn($this->prophesize(ServerUrlHelper::class)->reveal());
     }
 
-    public function fetchPlatesEngine(PlatesRenderer $plates)
+    public function fetchPlatesEngine(PlatesRenderer $plates): Engine
     {
         $r = new ReflectionProperty($plates, 'template');
         $r->setAccessible(true);
         return $r->getValue($plates);
     }
 
-    public function getConfigurationPaths()
+    public function getConfigurationPaths(): array
     {
         return [
             'foo' => __DIR__ . '/TestAsset/bar',
-            1 => __DIR__ . '/TestAsset/one',
+            1     => __DIR__ . '/TestAsset/one',
             'bar' => [
                 __DIR__ . '/TestAsset/baz',
                 __DIR__ . '/TestAsset/bat',
             ],
-            0 => [
+            0     => [
                 __DIR__ . '/TestAsset/two',
                 __DIR__ . '/TestAsset/three',
             ],
         ];
     }
 
-    public function assertPathsHasNamespace($namespace, array $paths, $message = null)
+    public function assertPathsHasNamespace(?string $namespace, array $paths, ?string $message = null): void
     {
         $message = $message ?: sprintf('Paths do not contain namespace %s', $namespace ?: 'null');
 
@@ -99,7 +100,7 @@ class PlatesRendererFactoryTest extends TestCase
         $this->assertTrue($found, $message);
     }
 
-    public function assertPathNamespaceCount($expected, $namespace, array $paths, $message = null)
+    public function assertPathNamespaceCount(int $expected, ?string $namespace, array $paths, ?string $message = null)
     {
         $message = $message ?: sprintf('Did not find %d paths with namespace %s', $expected, $namespace ?: 'null');
 
@@ -113,7 +114,7 @@ class PlatesRendererFactoryTest extends TestCase
         $this->assertSame($expected, $count, $message);
     }
 
-    public function assertPathNamespaceContains($expected, $namespace, array $paths, $message = null)
+    public function assertPathNamespaceContains(string $expected, ?string $namespace, array $paths, ?string $message = null): void
     {
         $message = $message ?: sprintf('Did not find path %s in namespace %s', $expected, $namespace ?: null);
 
@@ -127,29 +128,27 @@ class PlatesRendererFactoryTest extends TestCase
         $this->assertContains($expected, $found, $message);
     }
 
-    public function testCallingFactoryWithNoConfigReturnsPlatesInstance()
+    public function testCallingFactoryWithNoConfigReturnsPlatesInstance(): PlatesRenderer
     {
         $this->container->has('config')->willReturn(false);
         $this->configureEngineService();
         $factory = new PlatesRendererFactory();
-        $plates = $factory($this->container->reveal());
+        $plates  = $factory($this->container->reveal());
         $this->assertInstanceOf(PlatesRenderer::class, $plates);
         return $plates;
     }
 
     /**
      * @depends testCallingFactoryWithNoConfigReturnsPlatesInstance
-     *
-     * @param PlatesRenderer $plates
      */
-    public function testUnconfiguredPlatesInstanceContainsNoPaths(PlatesRenderer $plates)
+    public function testUnconfiguredPlatesInstanceContainsNoPaths(PlatesRenderer $plates): void
     {
         $paths = $plates->getPaths();
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertEmpty($paths);
     }
 
-    public function testConfiguresTemplateSuffix()
+    public function testConfiguresTemplateSuffix(): void
     {
         $config = [
             'templates' => [
@@ -160,23 +159,21 @@ class PlatesRendererFactoryTest extends TestCase
         $this->container->get('config')->willReturn($config);
         $this->configureEngineService();
         $factory = new PlatesRendererFactory();
-        $plates = $factory($this->container->reveal());
+        $plates  = $factory($this->container->reveal());
 
         $engine = $this->fetchPlatesEngine($plates);
-        $r = new ReflectionProperty($engine, 'fileExtension');
-        $r->setAccessible(true);
-        $extension = $r->getValue($engine);
-        $this->assertAttributeSame($config['templates']['extension'], 'fileExtension', $extension);
+
+        $this->assertEquals($config['templates']['extension'], $engine->getFileExtension());
     }
 
-    public function testExceptionIsRaisedIfMultiplePathsSpecifyDefaultNamespace()
+    public function testExceptionIsRaisedIfMultiplePathsSpecifyDefaultNamespace(): void
     {
         $config = [
             'templates' => [
                 'paths' => [
                     0 => __DIR__ . '/TestAsset/bar',
                     1 => __DIR__ . '/TestAsset/baz',
-                ]
+                ],
             ],
         ];
         $this->container->has('config')->willReturn(true);
@@ -192,7 +189,7 @@ class PlatesRendererFactoryTest extends TestCase
         $this->assertTrue($this->errorCaught, 'Did not detect duplicate path for default namespace');
     }
 
-    public function testExceptionIsRaisedIfMultiplePathsInSameNamespace()
+    public function testExceptionIsRaisedIfMultiplePathsInSameNamespace(): void
     {
         $config = [
             'templates' => [
@@ -214,13 +211,13 @@ class PlatesRendererFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testConfiguresPaths()
+    public function testConfiguresPaths(): void
     {
         $config = [
             'templates' => [
                 'paths' => [
                     'foo' => __DIR__ . '/TestAsset/bar',
-                    1 => __DIR__ . '/TestAsset/one',
+                    1     => __DIR__ . '/TestAsset/one',
                     'bar' => __DIR__ . '/TestAsset/baz',
                 ],
             ],
@@ -229,7 +226,7 @@ class PlatesRendererFactoryTest extends TestCase
         $this->container->get('config')->willReturn($config);
         $this->configureEngineService();
         $factory = new PlatesRendererFactory();
-        $plates = $factory($this->container->reveal());
+        $plates  = $factory($this->container->reveal());
 
         $paths = $plates->getPaths();
         $this->assertPathsHasNamespace('foo', $paths);
@@ -245,7 +242,7 @@ class PlatesRendererFactoryTest extends TestCase
         $this->assertPathNamespaceContains(__DIR__ . '/TestAsset/one', null, $paths);
     }
 
-    public function testWillPullPlatesEngineFromContainerIfPresent()
+    public function testWillPullPlatesEngineFromContainerIfPresent(): void
     {
         $engine = $this->prophesize(PlatesEngine::class);
         $this->container->has(PlatesEngine::class)->willReturn(true);
@@ -253,8 +250,13 @@ class PlatesRendererFactoryTest extends TestCase
 
         $this->container->has('config')->willReturn(false);
 
-        $factory = new PlatesRendererFactory();
+        $factory  = new PlatesRendererFactory();
         $renderer = $factory($this->container->reveal());
-        $this->assertAttributeSame($engine->reveal(), 'template', $renderer);
+
+        $class   = new \ReflectionClass($renderer);
+        $property = $class->getProperty('template');
+        $property->setAccessible(true);
+        $template = $property->getValue($renderer);
+        $this->assertSame($engine->reveal(), $template);
     }
 }

--- a/test/PlatesRendererFactoryTest.php
+++ b/test/PlatesRendererFactoryTest.php
@@ -114,8 +114,12 @@ class PlatesRendererFactoryTest extends TestCase
         $this->assertSame($expected, $count, $message);
     }
 
-    public function assertPathNamespaceContains(string $expected, ?string $namespace, array $paths, ?string $message = null): void
-    {
+    public function assertPathNamespaceContains(
+        string $expected,
+        ?string $namespace,
+        array $paths,
+        ?string $message = null
+    ): void {
         $message = $message ?: sprintf('Did not find path %s in namespace %s', $expected, $namespace ?: null);
 
         $found = [];

--- a/test/PlatesRendererTest.php
+++ b/test/PlatesRendererTest.php
@@ -16,8 +16,8 @@ use Mezzio\Plates\PlatesRenderer;
 use Mezzio\Template\Exception;
 use Mezzio\Template\TemplatePath;
 use PHPUnit\Framework\TestCase;
-
 use Prophecy\PhpUnit\ProphecyTrait;
+
 use function array_shift;
 use function file_get_contents;
 use function restore_error_handler;
@@ -250,7 +250,7 @@ class PlatesRendererTest extends TestCase
 
         // @fixme hack to work around https://github.com/thephpleague/plates/issues/60, remove if ever merged
         set_error_handler(function ($error, $message) {
-            $this->assertContains('Undefined variable: name', $message);
+            $this->assertStringContainsString('Undefined variable: name', $message);
             return true;
         }, E_NOTICE);
         $renderer->render('plates-2');

--- a/test/PlatesRendererTest.php
+++ b/test/PlatesRendererTest.php
@@ -17,6 +17,7 @@ use Mezzio\Template\Exception;
 use Mezzio\Template\TemplatePath;
 use PHPUnit\Framework\TestCase;
 
+use Prophecy\PhpUnit\ProphecyTrait;
 use function array_shift;
 use function file_get_contents;
 use function restore_error_handler;
@@ -31,35 +32,33 @@ use const E_USER_WARNING;
 
 class PlatesRendererTest extends TestCase
 {
-    /**
-     * @var Engine
-     */
+    use ProphecyTrait;
+
+    /** @var Engine */
     private $platesEngine;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $error;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->error = false;
+        $this->error        = false;
         $this->platesEngine = new Engine();
     }
 
-    public function assertTemplatePath($path, TemplatePath $templatePath, $message = null)
+    public function assertTemplatePath(string $path, TemplatePath $templatePath, ?string $message = null)
     {
         $message = $message ?: sprintf('Failed to assert TemplatePath contained path %s', $path);
         $this->assertEquals($path, $templatePath->getPath(), $message);
     }
 
-    public function assertTemplatePathString($path, TemplatePath $templatePath, $message = null)
+    public function assertTemplatePathString(string $path, TemplatePath $templatePath, ?string $message = null)
     {
         $message = $message ?: sprintf('Failed to assert TemplatePath casts to string path %s', $path);
         $this->assertEquals($path, (string) $templatePath, $message);
     }
 
-    public function assertTemplatePathNamespace($namespace, TemplatePath $templatePath, $message = null)
+    public function assertTemplatePathNamespace(string $namespace, TemplatePath $templatePath, ?string $message = null)
     {
         $message = $message ?: sprintf(
             'Failed to assert TemplatePath namespace matched %s',
@@ -68,16 +67,17 @@ class PlatesRendererTest extends TestCase
         $this->assertEquals($namespace, $templatePath->getNamespace(), $message);
     }
 
-    public function assertEmptyTemplatePathNamespace(TemplatePath $templatePath, $message = null)
+    public function assertEmptyTemplatePathNamespace(TemplatePath $templatePath, ?string $message = null)
     {
         $message = $message ?: 'Failed to assert TemplatePath namespace was empty';
         $this->assertEmpty($templatePath->getNamespace(), $message);
     }
 
-    public function assertEqualTemplatePath(TemplatePath $expected, TemplatePath $received, $message = null)
+    public function assertEqualTemplatePath(TemplatePath $expected, TemplatePath $received, ?string $message = null)
     {
         $message = $message ?: 'Failed to assert TemplatePaths are equal';
-        if ($expected->getPath() !== $received->getPath()
+        if (
+            $expected->getPath() !== $received->getPath()
             || $expected->getNamespace() !== $received->getNamespace()
         ) {
             $this->fail($message);
@@ -98,12 +98,12 @@ class PlatesRendererTest extends TestCase
         $this->assertEmpty($renderer->getPaths());
     }
 
-    public function testCanAddPath()
+    public function testCanAddPath(): PlatesRenderer
     {
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
         $paths = $renderer->getPaths();
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertCount(1, $paths);
         $this->assertTemplatePath(__DIR__ . '/TestAsset', $paths[0]);
         $this->assertTemplatePathString(__DIR__ . '/TestAsset', $paths[0]);
@@ -122,7 +122,7 @@ class PlatesRendererTest extends TestCase
 
         set_error_handler(function ($error, $message) {
             $this->error = true;
-            $this->assertContains('duplicate', $message);
+            $this->assertStringContainsString('duplicate', $message);
             return true;
         }, E_USER_WARNING);
         $renderer->addPath(__DIR__);
@@ -131,7 +131,7 @@ class PlatesRendererTest extends TestCase
         $this->assertTrue($this->error, 'Error handler was not triggered when calling addPath() multiple times');
 
         $paths = $renderer->getPaths();
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertCount(1, $paths);
         $test = array_shift($paths);
         $this->assertEqualTemplatePath($path, $test);
@@ -142,7 +142,7 @@ class PlatesRendererTest extends TestCase
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset', 'test');
         $paths = $renderer->getPaths();
-        $this->assertInternalType('array', $paths);
+        $this->assertIsArray($paths);
         $this->assertCount(1, $paths);
         $this->assertTemplatePath(__DIR__ . '/TestAsset', $paths[0]);
         $this->assertTemplatePathString(__DIR__ . '/TestAsset', $paths[0]);
@@ -153,15 +153,15 @@ class PlatesRendererTest extends TestCase
     {
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Plates';
-        $result = $renderer->render('plates', [ 'name' => $name ]);
-        $this->assertContains($name, $result);
+        $name   = 'Plates';
+        $result = $renderer->render('plates', ['name' => $name]);
+        $this->assertStringContainsString($name, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
         $content = str_replace('<?=$this->e($name)?>', $name, $content);
         $this->assertEquals($content, $result);
     }
 
-    public function invalidParameterValues()
+    public function invalidParameterValues(): array
     {
         return [
             'true'       => [true],
@@ -176,7 +176,6 @@ class PlatesRendererTest extends TestCase
 
     /**
      * @dataProvider invalidParameterValues
-     *
      * @param mixed $params
      */
     public function testRenderRaisesExceptionForInvalidParameterTypes($params)
@@ -190,12 +189,12 @@ class PlatesRendererTest extends TestCase
     {
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $result = $renderer->render('plates-null', null);
+        $result  = $renderer->render('plates-null', null);
         $content = file_get_contents(__DIR__ . '/TestAsset/plates-null.php');
         $this->assertEquals($content, $result);
     }
 
-    public function objectParameterValues()
+    public function objectParameterValues(): array
     {
         $names = [
             'stdClass'    => uniqid(),
@@ -210,7 +209,6 @@ class PlatesRendererTest extends TestCase
 
     /**
      * @dataProvider objectParameterValues
-     *
      * @param object $params
      * @param string $search
      */
@@ -219,7 +217,7 @@ class PlatesRendererTest extends TestCase
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
         $result = $renderer->render('plates', $params);
-        $this->assertContains($search, $result);
+        $this->assertStringContainsString($search, $result);
         $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
         $content = str_replace('<?=$this->e($name)?>', $search, $content);
         $this->assertEquals($content, $result);
@@ -245,7 +243,7 @@ class PlatesRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
         $name = 'Plates';
         $renderer->addDefaultParam('plates', 'name', $name);
-        $result = $renderer->render('plates');
+        $result  = $renderer->render('plates');
         $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
         $content = str_replace('<?=$this->e($name)?>', $name, $content);
         $this->assertEquals($content, $result);
@@ -268,11 +266,11 @@ class PlatesRendererTest extends TestCase
         $renderer->addPath(__DIR__ . '/TestAsset');
         $name = 'Plates';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
-        $result = $renderer->render('plates');
+        $result  = $renderer->render('plates');
         $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
         $content = str_replace('<?=$this->e($name)?>', $name, $content);
         $this->assertEquals($content, $result);
-        $result = $renderer->render('plates-2');
+        $result  = $renderer->render('plates-2');
         $content = file_get_contents(__DIR__ . '/TestAsset/plates-2.php');
         $content = str_replace('<?=$this->e($name)?>', $name, $content);
         $this->assertEquals($content, $result);
@@ -282,15 +280,15 @@ class PlatesRendererTest extends TestCase
     {
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Plates';
+        $name  = 'Plates';
         $name2 = 'Saucers';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
         $renderer->addDefaultParam('plates-2', 'name', $name2);
-        $result = $renderer->render('plates');
+        $result  = $renderer->render('plates');
         $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
         $content = str_replace('<?=$this->e($name)?>', $name, $content);
         $this->assertEquals($content, $result);
-        $result = $renderer->render('plates-2');
+        $result  = $renderer->render('plates-2');
         $content = file_get_contents(__DIR__ . '/TestAsset/plates-2.php');
         $content = str_replace('<?=$this->e($name)?>', $name2, $content);
         $this->assertEquals($content, $result);
@@ -300,10 +298,10 @@ class PlatesRendererTest extends TestCase
     {
         $renderer = new PlatesRenderer();
         $renderer->addPath(__DIR__ . '/TestAsset');
-        $name = 'Plates';
+        $name  = 'Plates';
         $name2 = 'Saucers';
         $renderer->addDefaultParam($renderer::TEMPLATE_ALL, 'name', $name);
-        $result = $renderer->render('plates', ['name' => $name2]);
+        $result  = $renderer->render('plates', ['name' => $name2]);
         $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
         $content = str_replace('<?=$this->e($name)?>', $name2, $content);
         $this->assertEquals($content, $result);

--- a/test/TestAsset/TestExtension.php
+++ b/test/TestAsset/TestExtension.php
@@ -15,6 +15,7 @@ use League\Plates\Extension\ExtensionInterface;
 
 class TestExtension implements ExtensionInterface
 {
+    /** @var Engine */
     public static $engine;
 
     public function register(Engine $engine)


### PR DESCRIPTION
This patch builds on #3, and adds a few QA changes (addition of composer lockfile changes, CS fixes, updates to PHPUnit configuration, and updates to dependency constraints). It primarily exists to ensure the CI workflow runs, as it currently has a bug that prevents having patch branches named the same as the target branch.
