### PR TITLE
Make plates engine service available

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -56,31 +56,6 @@
       <code>is_object($templateName)</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="src/PlatesRendererFactory.php">
-    <MixedArgument occurrences="3">
-      <code>$config['extension']</code>
-      <code>$namespace</code>
-      <code>$path</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['templates']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="7">
-      <code>$allPaths</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$namespace</code>
-      <code>$namespace</code>
-      <code>$path</code>
-      <code>$paths</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>PlatesEngine</code>
-    </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$container-&gt;get(PlatesEngine::class)</code>
-    </MixedReturnStatement>
-  </file>
   <file src="test/ConfigProviderTest.php">
     <RedundantCondition occurrences="1">
       <code>assertIsArray</code>
@@ -295,8 +270,7 @@
     </UndefinedClass>
   </file>
   <file src="test/PlatesRendererFactoryTest.php">
-    <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="5">
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
@@ -307,7 +281,7 @@
     <MixedInferredReturnType occurrences="1">
       <code>Engine</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="21">
+    <MixedMethodCall occurrences="17">
       <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
@@ -336,7 +310,7 @@
     <PossiblyNullArgument occurrences="1">
       <code>$namespace ?: null</code>
     </PossiblyNullArgument>
-    <PossiblyUndefinedMethod occurrences="27">
+    <PossiblyUndefinedMethod occurrences="22">
       <code>get</code>
       <code>get</code>
       <code>get</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -23,19 +23,31 @@
     <InvalidStringClass occurrences="1">
       <code>new $extension()</code>
     </InvalidStringClass>
-    <MixedArgument occurrences="3">
+    <MixedArgument occurrences="7">
+      <code>$config['extension']</code>
       <code>$container-&gt;get(Extension\EscaperExtension::class)</code>
       <code>$container-&gt;get(Extension\UrlExtension::class)</code>
       <code>$extension</code>
+      <code>$namespace</code>
+      <code>$path</code>
+      <code>$path</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
+    <MixedArrayAccess occurrences="2">
       <code>$config['plates']</code>
+      <code>$config['templates']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment occurrences="11">
+      <code>$allPaths</code>
+      <code>$config</code>
+      <code>$config</code>
       <code>$config</code>
       <code>$config</code>
       <code>$extension</code>
       <code>$extension</code>
+      <code>$namespace</code>
+      <code>$namespace</code>
+      <code>$path</code>
+      <code>$paths</code>
     </MixedAssignment>
   </file>
   <file src="src/PlatesRenderer.php">
@@ -188,8 +200,11 @@
     </PossiblyUndefinedMethod>
   </file>
   <file src="test/PlatesEngineFactoryTest.php">
-    <MixedArgument occurrences="10">
+    <InvalidArgument occurrences="1"/>
+    <MixedArgument occurrences="12">
       <code>$helper</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
@@ -207,7 +222,11 @@
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="23">
+    <MixedMethodCall occurrences="27">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
@@ -232,7 +251,7 @@
       <code>willReturn</code>
       <code>willReturn</code>
     </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="30">
+    <PossiblyUndefinedMethod occurrences="36">
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -240,6 +259,8 @@
       <code>get</code>
       <code>get</code>
       <code>get</code>
+      <code>get</code>
+      <code>get</code>
       <code>has</code>
       <code>has</code>
       <code>has</code>
@@ -256,6 +277,10 @@
       <code>has</code>
       <code>has</code>
       <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
       <code>reveal</code>
       <code>reveal</code>
       <code>reveal</code>
@@ -268,10 +293,15 @@
       <code>TestExtension</code>
       <code>\ZendTest\Expressive\Plates\stdClass</code>
     </UndefinedClass>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;errorCaught</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="1">
+      <code>$this-&gt;errorCaught</code>
+    </UndefinedThisPropertyFetch>
   </file>
   <file src="test/PlatesRendererFactoryTest.php">
     <MixedArgument occurrences="5">
-      <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
@@ -282,10 +312,6 @@
       <code>Engine</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="17">
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
-      <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
@@ -317,7 +343,6 @@
       <code>get</code>
       <code>get</code>
       <code>get</code>
-      <code>get</code>
       <code>has</code>
       <code>has</code>
       <code>has</code>
@@ -329,10 +354,6 @@
       <code>has</code>
       <code>has</code>
       <code>has</code>
-      <code>has</code>
-      <code>has</code>
-      <code>has</code>
-      <code>reveal</code>
       <code>reveal</code>
       <code>reveal</code>
       <code>reveal</code>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mezzio\Plates;
 
 use Mezzio\Template\TemplateRendererInterface;
+use League\Plates\Engine as PlatesEngine;
 
 class ConfigProvider
 {
@@ -27,6 +28,7 @@ class ConfigProvider
                 'Zend\Expressive\Plates\PlatesRenderer'              => PlatesRenderer::class,
             ],
             'factories' => [
+                PlatesEngine::class => PlatesEngineFactory::class,
                 PlatesRenderer::class => PlatesRendererFactory::class,
             ],
         ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Plates;
 
-use Mezzio\Template\TemplateRendererInterface;
 use League\Plates\Engine as PlatesEngine;
+use Mezzio\Template\TemplateRendererInterface;
 
 class ConfigProvider
 {
@@ -28,7 +28,7 @@ class ConfigProvider
                 'Zend\Expressive\Plates\PlatesRenderer'              => PlatesRenderer::class,
             ],
             'factories' => [
-                PlatesEngine::class => PlatesEngineFactory::class,
+                PlatesEngine::class   => PlatesEngineFactory::class,
                 PlatesRenderer::class => PlatesRendererFactory::class,
             ],
         ];

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -66,6 +66,7 @@ class PlatesEngineFactory
 
         // Add template paths
         $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
+
         foreach ($allPaths as $namespace => $paths) {
             $namespace = is_numeric($namespace) ? null : $namespace;
             foreach ((array) $paths as $path) {
@@ -74,7 +75,12 @@ class PlatesEngineFactory
                     continue;
                 }
 
-                $engine->addFolder($path, $namespace, true);
+                if (! $namespace) {
+                    trigger_error('Cannot add duplicate un-namespaced path in Plates template adapter', E_USER_WARNING);
+                    continue;
+                }
+
+                $engine->addFolder($namespace, $path, true);
             }
         }
 

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -10,6 +10,7 @@ use Mezzio\Helper;
 use Psr\Container\ContainerInterface;
 
 use function class_exists;
+use function get_class;
 use function gettype;
 use function is_array;
 use function is_numeric;
@@ -173,7 +174,7 @@ class PlatesEngineFactory
             throw new Exception\InvalidExtensionException(sprintf(
                 '%s expects extension instances, service names, or class names; received %s',
                 self::class,
-                is_object($extension) ? $extension::class : gettype($extension)
+                is_object($extension) ? get_class($extension) : gettype($extension)
             ));
         }
 
@@ -194,7 +195,7 @@ class PlatesEngineFactory
                 '%s expects extension services to implement %s ; received %s',
                 self::class,
                 ExtensionInterface::class,
-                is_object($extension) ? $extension::class : gettype($extension)
+                is_object($extension) ? get_class($extension) : gettype($extension)
             ));
         }
 

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -10,12 +10,15 @@ use Mezzio\Helper;
 use Psr\Container\ContainerInterface;
 
 use function class_exists;
-use function get_class;
 use function gettype;
 use function is_array;
+use function is_numeric;
 use function is_object;
 use function is_string;
 use function sprintf;
+use function trigger_error;
+
+use const E_USER_WARNING;
 
 /**
  * Create and return a Plates engine instance.
@@ -170,7 +173,7 @@ class PlatesEngineFactory
             throw new Exception\InvalidExtensionException(sprintf(
                 '%s expects extension instances, service names, or class names; received %s',
                 self::class,
-                is_object($extension) ? get_class($extension) : gettype($extension)
+                is_object($extension) ? $extension::class : gettype($extension)
             ));
         }
 
@@ -191,7 +194,7 @@ class PlatesEngineFactory
                 '%s expects extension services to implement %s ; received %s',
                 self::class,
                 ExtensionInterface::class,
-                is_object($extension) ? get_class($extension) : gettype($extension)
+                is_object($extension) ? $extension::class : gettype($extension)
             ));
         }
 

--- a/src/PlatesEngineFactory.php
+++ b/src/PlatesEngineFactory.php
@@ -56,6 +56,28 @@ class PlatesEngineFactory
             $this->injectExtensions($container, $engine, $config['extensions']);
         }
 
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['templates'] ?? [];
+
+        // Set file extension
+        if (isset($config['extension'])) {
+            $engine->setFileExtension($config['extension']);
+        }
+
+        // Add template paths
+        $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
+        foreach ($allPaths as $namespace => $paths) {
+            $namespace = is_numeric($namespace) ? null : $namespace;
+            foreach ((array) $paths as $path) {
+                if (! $namespace && ! $engine->getDirectory()) {
+                    $engine->setDirectory($path);
+                    continue;
+                }
+
+                $engine->addFolder($path, $namespace, true);
+            }
+        }
+
         return $engine;
     }
 

--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -12,7 +12,6 @@ use Mezzio\Template\TemplatePath;
 use Mezzio\Template\TemplateRendererInterface;
 use ReflectionProperty;
 
-use function get_class;
 use function gettype;
 use function is_object;
 use function is_string;
@@ -95,14 +94,14 @@ class PlatesRenderer implements TemplateRendererInterface
         if (! is_string($templateName) || empty($templateName)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '$templateName must be a non-empty string; received %s',
-                is_object($templateName) ? get_class($templateName) : gettype($templateName)
+                is_object($templateName) ? $templateName::class : gettype($templateName)
             ));
         }
 
         if (! is_string($param) || empty($param)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '$param must be a non-empty string; received %s',
-                is_object($param) ? get_class($param) : gettype($param)
+                is_object($param) ? $param::class : gettype($param)
             ));
         }
 

--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -12,6 +12,7 @@ use Mezzio\Template\TemplatePath;
 use Mezzio\Template\TemplateRendererInterface;
 use ReflectionProperty;
 
+use function get_class;
 use function gettype;
 use function is_object;
 use function is_string;
@@ -94,14 +95,14 @@ class PlatesRenderer implements TemplateRendererInterface
         if (! is_string($templateName) || empty($templateName)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '$templateName must be a non-empty string; received %s',
-                is_object($templateName) ? $templateName::class : gettype($templateName)
+                is_object($templateName) ? get_class($templateName) : gettype($templateName)
             ));
         }
 
         if (! is_string($param) || empty($param)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '$param must be a non-empty string; received %s',
-                is_object($param) ? $param::class : gettype($param)
+                is_object($param) ? get_class($param) : gettype($param)
             ));
         }
 

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -7,9 +7,6 @@ namespace Mezzio\Plates;
 use League\Plates\Engine as PlatesEngine;
 use Psr\Container\ContainerInterface;
 
-use function is_array;
-use function is_numeric;
-
 /**
  * Create and return a Plates template instance.
  *

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -36,30 +36,9 @@ class PlatesRendererFactory
 {
     public function __invoke(ContainerInterface $container): PlatesRenderer
     {
-        $config = $container->has('config') ? $container->get('config') : [];
-        $config = $config['templates'] ?? [];
+        $engine = $this->getEngine($container);
 
-        // Create the engine instance:
-        $engine = $this->createEngine($container);
-
-        // Set file extension
-        if (isset($config['extension'])) {
-            $engine->setFileExtension($config['extension']);
-        }
-
-        // Inject engine
-        $plates = new PlatesRenderer($engine);
-
-        // Add template paths
-        $allPaths = isset($config['paths']) && is_array($config['paths']) ? $config['paths'] : [];
-        foreach ($allPaths as $namespace => $paths) {
-            $namespace = is_numeric($namespace) ? null : $namespace;
-            foreach ((array) $paths as $path) {
-                $plates->addPath($path, $namespace);
-            }
-        }
-
-        return $plates;
+        return new PlatesRenderer($engine);
     }
 
     /**
@@ -70,13 +49,21 @@ class PlatesRendererFactory
      * Otherwise, invokes the PlatesEngineFactory with the $container to create
      * and return the instance.
      */
-    private function createEngine(ContainerInterface $container): PlatesEngine
+    private function getEngine(ContainerInterface $container): PlatesEngine
     {
         if ($container->has(PlatesEngine::class)) {
             return $container->get(PlatesEngine::class);
         }
 
-        $engineFactory = new PlatesEngineFactory();
-        return $engineFactory($container);
+        trigger_error(sprintf(
+            '%s now expects you to register the factory %s for the service %s; '
+            . 'please update your dependency configuration.',
+            self::class,
+            PlatesEngineFactory::class,
+            PlatesEngine::class
+        ), E_USER_DEPRECATED);
+
+        $factory = new PlatesEngineFactory();
+        return $factory($container);
     }
 }

--- a/src/PlatesRendererFactory.php
+++ b/src/PlatesRendererFactory.php
@@ -36,34 +36,9 @@ class PlatesRendererFactory
 {
     public function __invoke(ContainerInterface $container): PlatesRenderer
     {
-        $engine = $this->getEngine($container);
+        /** @var PlatesEngine $engine */
+        $engine = $container->get(PlatesEngine::class);
 
         return new PlatesRenderer($engine);
-    }
-
-    /**
-     * Create and return a Plates Engine instance.
-     *
-     * If the container has the League\Plates\Engine service, returns it.
-     *
-     * Otherwise, invokes the PlatesEngineFactory with the $container to create
-     * and return the instance.
-     */
-    private function getEngine(ContainerInterface $container): PlatesEngine
-    {
-        if ($container->has(PlatesEngine::class)) {
-            return $container->get(PlatesEngine::class);
-        }
-
-        trigger_error(sprintf(
-            '%s now expects you to register the factory %s for the service %s; '
-            . 'please update your dependency configuration.',
-            self::class,
-            PlatesEngineFactory::class,
-            PlatesEngine::class
-        ), E_USER_DEPRECATED);
-
-        $factory = new PlatesEngineFactory();
-        return $factory($container);
     }
 }

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -6,12 +6,14 @@ namespace MezzioTest\Plates;
 
 use League\Plates\Engine as PlatesEngine;
 use League\Plates\Extension\ExtensionInterface;
+use LogicException;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Plates\Exception\InvalidExtensionException;
 use Mezzio\Plates\Extension\EscaperExtension;
 use Mezzio\Plates\Extension\UrlExtension;
 use Mezzio\Plates\PlatesEngineFactory;
+use Mezzio\Plates\PlatesRendererFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -219,6 +221,50 @@ class PlatesEngineFactoryTest extends TestCase
         $factory = new PlatesEngineFactory();
         $this->expectException(InvalidExtensionException::class);
         $this->expectExceptionMessage('ExtensionInterface');
+        $factory($this->container->reveal());
+    }
+
+    public function testExceptionIsRaisedIfMultiplePathsSpecifyDefaultNamespace(): void
+    {
+        $config = [
+            'templates' => [
+                'paths' => [
+                    0 => __DIR__ . '/TestAsset/bar',
+                    1 => __DIR__ . '/TestAsset/baz',
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $factory = new PlatesEngineFactory();
+
+        // phpcs:ignore WebimpressCodingStandard.NamingConventions.ValidVariableName.NotCamelCaps
+        set_error_handler(function (int $_errno, string $_errstr): void {
+            $this->errorCaught = true;
+        }, E_USER_WARNING);
+        $factory($this->container->reveal());
+        restore_error_handler();
+        $this->assertTrue($this->errorCaught, 'Did not detect duplicate path for default namespace');
+    }
+
+    public function testExceptionIsRaisedIfMultiplePathsInSameNamespace(): void
+    {
+        $config = [
+            'templates' => [
+                'paths' => [
+                    'bar' => [
+                        __DIR__ . '/TestAsset/baz',
+                        __DIR__ . '/TestAsset/bat',
+                    ],
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $factory = new PlatesEngineFactory();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('already being used');
         $factory($this->container->reveal());
     }
 

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -13,7 +13,6 @@ use Mezzio\Plates\Exception\InvalidExtensionException;
 use Mezzio\Plates\Extension\EscaperExtension;
 use Mezzio\Plates\Extension\UrlExtension;
 use Mezzio\Plates\PlatesEngineFactory;
-use Mezzio\Plates\PlatesRendererFactory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -23,6 +22,10 @@ use stdClass;
 use ZendTest\Expressive\Plates\TestAsset\TestExtension;
 
 use function is_string;
+use function restore_error_handler;
+use function set_error_handler;
+
+use const E_USER_WARNING;
 
 class PlatesEngineFactoryTest extends TestCase
 {

--- a/test/PlatesRendererFactoryTest.php
+++ b/test/PlatesRendererFactoryTest.php
@@ -6,7 +6,6 @@ namespace MezzioTest\Plates;
 
 use League\Plates\Engine;
 use League\Plates\Engine as PlatesEngine;
-use LogicException;
 use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Plates\Extension\EscaperExtension;
@@ -22,11 +21,7 @@ use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionProperty;
 
-use function restore_error_handler;
-use function set_error_handler;
 use function sprintf;
-
-use const E_USER_WARNING;
 
 class PlatesRendererFactoryTest extends TestCase
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This make plates itself available as service and register and create it already correctly configured in the PlatesEngineFactory. This is similar how the mezzio-twigrenderer package works and so make things more consistent and possible to use the plates engine service directly.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
