### PR TITLE
Allow `'plates'` configuration to define its own file extension

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -989,16 +989,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
+                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
-                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
+                "reference": "4482b6409ca6bfc2af043a5711cd21ac3e7a8dfb",
                 "shasum": ""
             },
             "require": {
@@ -1040,7 +1040,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.0.0"
+                "source": "https://github.com/composer/pcre/tree/3.0.2"
             },
             "funding": [
                 {
@@ -1056,7 +1056,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-25T20:21:48+00:00"
+            "time": "2022-11-03T20:24:16+00:00"
         },
         {
             "name": "composer/semver",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
+<files psalm-version="4.29.0@7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3">
   <file src="src/Extension/EscaperExtensionFactory.php">
     <MixedArgument occurrences="1">
       <code>$config['encoding'] ?? null</code>
@@ -27,27 +27,21 @@
       <code>$config['extension']</code>
       <code>$container-&gt;get(Extension\EscaperExtension::class)</code>
       <code>$container-&gt;get(Extension\UrlExtension::class)</code>
-      <code>$extension</code>
-      <code>$namespace</code>
+      <code>$mezzioConfig</code>
       <code>$path</code>
       <code>$path</code>
+      <code>$platesConfig</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$config['plates']</code>
-      <code>$config['templates']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="11">
-      <code>$allPaths</code>
-      <code>$config</code>
-      <code>$config</code>
-      <code>$config</code>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$config['extensions']</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="6">
       <code>$config</code>
       <code>$extension</code>
-      <code>$extension</code>
-      <code>$namespace</code>
-      <code>$namespace</code>
+      <code>$mezzioConfig</code>
       <code>$path</code>
       <code>$paths</code>
+      <code>$platesConfig</code>
     </MixedAssignment>
   </file>
   <file src="src/PlatesRenderer.php">
@@ -201,8 +195,10 @@
   </file>
   <file src="test/PlatesEngineFactoryTest.php">
     <InvalidArgument occurrences="1"/>
-    <MixedArgument occurrences="12">
+    <MixedArgument occurrences="14">
       <code>$helper</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
       <code>$this-&gt;container-&gt;reveal()</code>
@@ -222,7 +218,11 @@
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="27">
+    <MixedMethodCall occurrences="31">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
       <code>willReturn</code>
@@ -251,7 +251,7 @@
       <code>willReturn</code>
       <code>willReturn</code>
     </MixedMethodCall>
-    <PossiblyUndefinedMethod occurrences="36">
+    <PossiblyUndefinedMethod occurrences="42">
       <code>get</code>
       <code>get</code>
       <code>get</code>
@@ -261,6 +261,8 @@
       <code>get</code>
       <code>get</code>
       <code>get</code>
+      <code>get</code>
+      <code>get</code>
       <code>has</code>
       <code>has</code>
       <code>has</code>
@@ -279,6 +281,10 @@
       <code>has</code>
       <code>has</code>
       <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
       <code>reveal</code>
       <code>reveal</code>
       <code>reveal</code>

--- a/test/PlatesEngineFactoryTest.php
+++ b/test/PlatesEngineFactoryTest.php
@@ -271,6 +271,41 @@ class PlatesEngineFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
+    public function testSetExtensionByTemplatesConfig(): void
+    {
+        $config = [
+            'templates' => [
+                'extension' => 'html.twig',
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $factory = new PlatesEngineFactory();
+
+        $engine = $factory($this->container->reveal());
+
+        $this->assertSame('html.twig', $engine->getFileExtension());
+    }
+
+    public function testOverrideExtensionByPlatesConfig(): void
+    {
+        $config = [
+            'templates' => [
+                'extension' => 'html.twig',
+            ],
+            'plates'    => [
+                'extension' => 'plates.php',
+            ],
+        ];
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
+        $factory = new PlatesEngineFactory();
+
+        $engine = $factory($this->container->reveal());
+
+        $this->assertSame('plates.php', $engine->getFileExtension());
+    }
+
     public function provideHelpersToUnregister(): array
     {
         return [


### PR DESCRIPTION
Signed-off-by: Alexander Schranz <alexander@sulu.io>


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Currently it is not possible to use twig and plates side by side as the "global" config `extension` config doesn't allow it. Why I personally would remove things like `paths`, `extension` into a `plates` specific config and not "abstract" it I did for bc reasons just make it possible to overwrite things like its done in twig renderer.

In twig such config already possible as twig config overwrite the `templates` configuration here the same way: https://github.com/mezzio/mezzio-twigrenderer/blob/57f301d01181f96f1379b8397ca285b856622efc/src/TwigRendererFactory.php#L59-L66

Example:

```php
class ConfigProvider
{
    public function __invoke(): array
    {
        return [
            // ...
            'plates' => [
                'extension' => 'php',
            ],
            'twig' => [
                'extension' => 'html.twig',
            ],
        ];
    }
}
```

# TODO

 - [x] Test